### PR TITLE
Ported library

### DIFF
--- a/src/main/scala/intent/core/expectations/contain.scala
+++ b/src/main/scala/intent/core/expectations/contain.scala
@@ -5,7 +5,7 @@ import scala.concurrent.Future
 import scala.collection.mutable.ListBuffer
 import scala.Array
 
-private def evalToContain[T](actual: IterableOnce[T],
+private def evalToContain[T](actual: IterableOnce[T] | Null,
                               expected: T,
                               expect: Expect[_],
                               listTypeName: String)
@@ -21,7 +21,7 @@ private def evalToContain[T](actual: IterableOnce[T],
 
   val seen = ListBuffer[String]()
   var found = false
-  val iterator = Option(actual).map(_.iterator).getOrElse(emptyIterator)
+  val iterator = Option(actual).map(_.nn.iterator).getOrElse(emptyIterator)
   val shouldNotFind = expect.isNegated
   var breakEarly = false
   var itemsChecked = 0

--- a/src/test/scala/intent/helpers/TestSuiteRunnerTester.scala
+++ b/src/test/scala/intent/helpers/TestSuiteRunnerTester.scala
@@ -9,7 +9,7 @@ import intent.runner.{TestSuiteRunner, TestSuiteError, TestSuiteResult}
 */
 trait TestSuiteRunnerTester(given ec: ExecutionContext) extends Subscriber[TestCaseResult] with
 
-  def suiteClassName: String
+  def suiteClassName: String | Null
 
   private object lock
   val runner = new TestSuiteRunner(cl)
@@ -17,13 +17,13 @@ trait TestSuiteRunnerTester(given ec: ExecutionContext) extends Subscriber[TestC
 
   def runAll(): Future[Either[TestSuiteError, TestSuiteResult]] =
     assert(suiteClassName != null, "Suite class name must be set")
-    runner.runSuite(suiteClassName)
+    runner.runSuite(suiteClassName.nn)
 
   def runWithEventSubscriber(): Future[Either[TestSuiteError, TestSuiteResult]] =
     assert(suiteClassName != null, "Suite class name must be set")
-    runner.runSuite(suiteClassName, Some(this))
+    runner.runSuite(suiteClassName.nn, Some(this))
 
-  def evaluate(): IntentStructure = runner.evaluateSuite(suiteClassName).fold(_ => ???, identity)
+  def evaluate(): IntentStructure = runner.evaluateSuite(suiteClassName.nn).fold(_ => ???, identity)
 
   def receivedEvents(): Seq[TestCaseResult] = events
 

--- a/src/test/scala/intent/runner/FocusedTest.scala
+++ b/src/test/scala/intent/runner/FocusedTest.scala
@@ -51,7 +51,7 @@ class FocusedTest extends TestSuite with State[FocusedTestCase] with
   )
 
 case class FocusedTestCase(
-  suiteClassName: String = null,
+  suiteClassName: String | Null = null,
   expectedSuccessful:Int = 0,
   expectedIgnored:Int = 0,
   focused: Boolean = false)(given ec: ExecutionContext) extends TestSuiteRunnerTester

--- a/src/test/scala/intent/runner/TestSuiteRunnerTest.scala
+++ b/src/test/scala/intent/runner/TestSuiteRunnerTest.scala
@@ -152,7 +152,7 @@ class TestSuiteRunnerTest extends TestSuite with State[TestSuiteTestCase] with
 /**
  * Wraps a runner for a specific test suite
  */
-case class TestSuiteTestCase(suiteClassName: String = null)(given ec: ExecutionContext) extends TestSuiteRunnerTester with
+case class TestSuiteTestCase(suiteClassName: String | Null = null)(given ec: ExecutionContext) extends TestSuiteRunnerTester with
 
   def emptyTestSuite = TestSuiteTestCase("intent.testdata.EmtpyTestSuite")
   def invalidTestSuiteClass = TestSuiteTestCase("foo.Bar")

--- a/src/test/scala/intent/suite/TestDiscoveryTest.scala
+++ b/src/test/scala/intent/suite/TestDiscoveryTest.scala
@@ -8,17 +8,17 @@ class TestDiscoveryTest extends TestSuite with State[TestDiscoveryTestState] wit
     "empty test suite" using (_.withSuite(EmtpyTestSuite())) to:
 
       "should have 0 tests" in:
-        st => expect(st.suite.allTestCases).toHaveLength(0)
+        st => expect(st.suite.nn.allTestCases).toHaveLength(0)
 
     "single level test suite" using (_.withSuite(SingleLevelTestSuite())) to:
 
       "should have 1 tests" in:
-        st => expect(st.suite.allTestCases).toHaveLength(1)
+        st => expect(st.suite.nn.allTestCases).toHaveLength(1)
 
     "nested test suite" using (_.withSuite(NestedTestsSuite())) to:
 
       "should have 3 tests" in:
-        st => expect(st.suite.allTestCases).toHaveLength(3)
+        st => expect(st.suite.nn.allTestCases).toHaveLength(3)
 
-case class TestDiscoveryTestState(suite: Stateless = null) with
+case class TestDiscoveryTestState(suite: Stateless | Null = null) with
   def withSuite(s: Stateless) = copy(suite = s)


### PR DESCRIPTION
LOC changed: 22

**Nullable variable** | 5
Variables that really can be null and should therefore have a `| Null` type.

**Nullable variable is used** | 7
Requires `.nn` to remove nullness.

**Overridden java array field** | 6
A Scala field overrides some Java array field. We need to use `Array[T | Null]` instead of `Array[T]` for the overriding to work.

**Overridden java arguments are never null** | 2
Argument should never be null, immediately remove nullness of parameter.

**Overridden java method returns array** | 3
Overridden java method returns an array. Java arrays have type `Array[T | Null]`. Returned array must thereby be converted to have type `Array[T | Null]`.

**Overridden java array contents are never null** | 2
Overridden array field of type `Array[T | Null]` should have type `Array[T]`. Use `.map(_.nn)` to fix.

**Overridding method returns array** | 1
If a method overrides a java method which returns an array, then the return type must be modified from `Array[T]` to `Array[T | Null]`. However, when this return value is then used, we need to cast it back to `Array[T]`.